### PR TITLE
Use pydantic >= 2.6.3 for Python 3.14 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ Cheetah3==3.2.6.post1
 lxml==5.1.0
 pyparsing==3.1.1
 plantuml==0.3.0
-pydantic==2.6.3
+pydantic>=2.6.3
 pyyaml==6.0.3


### PR DESCRIPTION
For Python 3.14 compatibility setting the dependency for pydantic to >= 2.6.3 allows for a venv to be built successfully.